### PR TITLE
Added like/dislike functionality for track queue

### DIFF
--- a/src/jukebox/dto/like-dislike-track.dto.ts
+++ b/src/jukebox/dto/like-dislike-track.dto.ts
@@ -1,0 +1,18 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsEnum, IsInt, Min } from 'class-validator';
+
+export enum TrackInteraction {
+  LIKE = 'like',
+  DISLIKE = 'dislike',
+}
+
+export class LikeDislikeTrackDto {
+  @ApiProperty({ description: 'The index of the track in the queue' })
+  @IsInt()
+  @Min(0)
+  queue_index: number;
+
+  @ApiProperty({ description: 'The interaction type', enum: TrackInteraction })
+  @IsEnum(TrackInteraction)
+  action: TrackInteraction;
+}

--- a/src/jukebox/jukebox.controller.ts
+++ b/src/jukebox/jukebox.controller.ts
@@ -27,6 +27,7 @@ import { JukeboxService } from './jukebox.service'
 import { AddTrackToQueueDto } from './track-queue/dtos/track-queue.dto'
 import { TrackQueueService } from './track-queue/track-queue.service'
 import { JukeboxSearchDto } from './dto/jukebox-search.dto'
+import { LikeDislikeTrackDto } from './dto/like-dislike-track.dto';
 
 @ApiTags('jukeboxes')
 @Controller('jukebox/')
@@ -185,4 +186,22 @@ export class JukeboxController {
     const account = await this.jukeboxSvc.getActiveSpotifyAccount(jukeboxId)
     return this.spotifySvc.searchTracks(account, body)
   }
+
+  @Post('/:jukebox_id/tracks-queue/like-dislike')
+async likeDislikeTrackInQueue(
+  @Param('jukebox_id') jukeboxId: number,
+  @Body() body: LikeDislikeTrackDto
+) {
+  const updatedTrack = await this.jukeboxSvc.interactWithTrackInQueue(
+    jukeboxId,
+    body.queue_index,
+    body.action
+  );
+
+  // Emit WebSocket event to update all clients
+  await this.jbxGateway.emitTrackQueueUpdate(jukeboxId);
+
+  return updatedTrack;
+}
+
 }

--- a/src/jukebox/jukebox.service.ts
+++ b/src/jukebox/jukebox.service.ts
@@ -21,6 +21,8 @@ import { QueuedTrackDto } from './dto/track.dto'
 import { UpdateJukeboxDto } from './dto/update-jukebox.dto'
 import { Jukebox, JukeboxLinkAssignment } from './entities/jukebox.entity'
 import { TrackQueueService } from './track-queue/track-queue.service'
+import { TrackInteraction } from './dto/like-dislike-track.dto';
+
 
 @Injectable()
 export class JukeboxService {
@@ -405,4 +407,31 @@ export class JukeboxService {
 
     return queuedTrack
   }
+
+  async interactWithTrackInQueue(
+    jukeboxId: number,
+    queueIndex: number,
+    action: TrackInteraction
+  ): Promise<IQueuedTrack> {
+    // Get the track at the specified position
+    const track = await this.queueSvc.getTrackAtPos(jukeboxId, queueIndex);
+    
+    if (!track) {
+      throw new BadRequestException(`No track found at position ${queueIndex} in the queue.`);
+    }
+  
+    // Update likes or dislikes
+    if (action === TrackInteraction.LIKE) {
+      track.interactions.likes += 1;
+    } else if (action === TrackInteraction.DISLIKE) {
+      track.interactions.dislikes += 1;
+    }
+  
+    // Save the updated track back to the queue
+    await this.queueSvc.setTrackAtPos(jukeboxId, track, queueIndex);
+    
+    return track;
+  }
+  
+
 }


### PR DESCRIPTION
Adds like/dislike functionality for tracks in queue.
-Added a new POST /api/v1/jukebox/:jukebox_id/tracks-queue/like-dislike route in jukebox.controller.ts that allows users to like or dislike a track at a given queue index
-Added updateTrackInteractions() function in jukebox.service.ts to handle liking/disliking tracks and update track interactions in the database.
-Added like-dislike-track DTO to handle errors and verification.
-Added a call to websocket in jukebox.gateway.ts to update front-end.